### PR TITLE
Task 0 0x11 printf project

### DIFF
--- a/get_func.c
+++ b/get_func.c
@@ -10,6 +10,9 @@
 int (*get_func(const char *s, unsigned int is))(va_list, char *, unsigned int)
 {
 	print_t functions[] = {
+		{"c", &print_chr},
+		{"s", &print_str},
+		{"%", &print_mod},
 		{NULL, NULL}
 		 };
 	int i = 0;

--- a/main.h
+++ b/main.h
@@ -19,6 +19,10 @@ typedef struct print
 	int (*f)(va_list ap, char *buf, unsigned int ibuf);
 } print_t;
 
+int print_chr(va_list ap, char *buf, unsigned int ibuf);
+int print_str(va_list ap, char *buf, unsigned int ibuf);
+int print_mod(va_list ap, char *buf, unsigned int ibuf);
+
 int _printf(const char *format, ...);
 int _putchar(char c);
 int _putbuf(const char *buf, unsigned int nbuf);

--- a/print_chr.c
+++ b/print_chr.c
@@ -1,0 +1,18 @@
+#include "main.h"
+
+/**
+  * print_chr - write a character to the buffer given s specifier
+  * @ap: array of arguments passed
+  * @buf: _printf buffer to store the character
+  * @ibuf: ithe index of buffer where character is to be stored
+  *
+  * Return: Always the index where character is stored.
+  */
+int print_chr(va_list ap, char *buf, unsigned int ibuf)
+{
+	char c;
+
+	c = va_arg(ap, int);
+	buf[ibuf] = c;
+	return (1);
+}

--- a/print_mod.c
+++ b/print_mod.c
@@ -1,0 +1,18 @@
+#include "main.h"
+
+/**
+  * print_mod - inserts the character % in to the buffer given specifier %
+  * @ap: array of arguments passed to _printf
+  * @buf: the buffer to write to
+  * @ibuf: ith index of the buffer to insert %
+  *
+  * Return: Always the length of characters inserted.
+  */
+int print_mod(va_list ap, char *buf, unsigned int ibuf)
+{
+	char c = '%';
+
+	(void) ap;
+	buf[ibuf] = c;
+	return (1);
+}

--- a/print_str.c
+++ b/print_str.c
@@ -1,0 +1,29 @@
+#include "main.h"
+
+/**
+  * print_str - insert string in to the buffer given specifier s
+  * @ap: array list of arguments passed
+  * @buf: _printf buffer to store the formated string
+  * @ibuf: ith index of the buffer to insert the characters
+  *
+  * Return: Alway the number of characters inserted.
+  */
+int print_str(va_list ap, char *buf, unsigned int ibuf)
+{
+	int i;
+	char *str;
+	char *emp = "(null)";
+
+	str = va_arg(ap, char *);
+	if (str == NULL)
+	{
+		for (i = 0; emp[i] != '\0'; i++)
+			write_to_buf(buf, emp[i], ibuf + i);
+		return (i);
+	}
+	for (i = 0; str[i] != '\0'; i++)
+	{
+		write_to_buf(buf, str[i], ibuf + i);
+	}
+	return (i);
+}


### PR DESCRIPTION
The _printf function subsidiary functions print_chr, print_str, and print_mod for the specifiers %c, %s, and %% respectively.